### PR TITLE
fix(collapsible): move active setter on close

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -142,7 +142,7 @@
         </ax-form-field>
       </ax-form>
 
-      <ax-pagination :max-visible="maxVisible" v-model="current" :total="-15" :per-page="1">
+      <ax-pagination :max-visible="maxVisible" v-model="current" :total="15" :per-page="1">
         <template #first-arrow="{ goto, isDisabled }">
           <li
             class="txt-blue arrow pb-1 grey light-4 bd-solid bd-1 bd-grey bd-light-3"

--- a/src/components/collapsible/Collapsible.vue
+++ b/src/components/collapsible/Collapsible.vue
@@ -148,6 +148,7 @@ export default defineComponent({
 
       ctx.emit('close');
 
+      isActive.value = false;
       setTimeout(() => {
         isAnimated.value = true;
         maxHeight.value = '0';
@@ -155,7 +156,6 @@ export default defineComponent({
 
       setTimeout(() => {
         display.value = '';
-        isActive.value = false;
         isAnimated.value = false;
       }, props.animationDuration + 10);
     };


### PR DESCRIPTION
The isActive value was set at the wrong time on close which was making the active class being removed when the collapsible was totally closed and not on click.