### PR TITLE
fix(tooltip): double timeout handling

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -101,7 +101,7 @@
         <ax-tooltip content="modal toggler">
           <ax-btn class="airforce dark-1 rounded-1 shadow-1" @click="modal = !modal">Toggle modal</ax-btn>
         </ax-tooltip>
-        <ax-tooltip content="sidenav toggler">
+        <ax-tooltip position="bottom" content="sidenav toggler">
           <ax-btn class="airforce dark-1 rounded-1 shadow-1 ml-2" @click="isSidenavOpened = !isSidenavOpened"
             >Toggle sidenav</ax-btn
           >

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -141,12 +141,15 @@ export default defineComponent({
       const scrollY = window.scrollY;
       const tooltipTop = parseFloat(tooltip.value.style.top);
 
+      console.log(scrollY * 2 + tooltipTop + 'px', scrollY + tooltipTop + 'px')
       props.position === 'top'
         ? (tooltip.value.style.top = scrollY * 2 + tooltipTop + 'px')
         : (tooltip.value.style.top = scrollY + tooltipTop + 'px');
+      console.log(tooltip.value.style.top)
     };
 
     const show = () => {
+      clearTimeout(timeoutRef.value);
       tooltip.value.style.display = 'block';
       setProperties();
       updatePosition();
@@ -176,7 +179,7 @@ export default defineComponent({
       tooltip.value.style.transform = 'translate(0)';
       tooltip.value.style.opacity = 0;
 
-      setTimeout(() => {
+      timeoutRef.value = setTimeout(() => {
         tooltip.value.style.display = 'none';
       }, props.animationDuration);
     };

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -141,11 +141,9 @@ export default defineComponent({
       const scrollY = window.scrollY;
       const tooltipTop = parseFloat(tooltip.value.style.top);
 
-      console.log(scrollY * 2 + tooltipTop + 'px', scrollY + tooltipTop + 'px')
       props.position === 'top'
         ? (tooltip.value.style.top = scrollY * 2 + tooltipTop + 'px')
         : (tooltip.value.style.top = scrollY + tooltipTop + 'px');
-      console.log(tooltip.value.style.top)
     };
 
     const show = () => {


### PR DESCRIPTION
This fix the timeout clearing handling.
The tooltip couldn't be shown back when the element was hovered while the tooltip was in the hide animation.